### PR TITLE
fix: set release as default Makefile target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -15,6 +15,7 @@ TEST_SENDER=author@localhost
 TEST_RECIPIENT=max.neuvians+staging-notify-1@cds-snc.ca
 
 .PHONY: dev generate-keys release release-test script-test-python test
+.DEFAULT_GOAL := release
 
 dev:
 	@echo "Starting dev server..."


### PR DESCRIPTION
# Summary
Update the Makefile to have the `release` be the default target.  This target is used by CodeQL when scanning Go.
